### PR TITLE
Revise Execution Broker documentation for 2026

### DIFF
--- a/notes/zrq/20260108-targets.md
+++ b/notes/zrq/20260108-targets.md
@@ -1,8 +1,37 @@
-Summary of where we are with Execution Broker.
+# Execution Broker in 2026
 
+Summary of where we are with Execution Broker at the start of 2026.
+
+## Execution Broker in 2025
 Target for 2025 has been to adapt Execution Broker to fit into the SRCNet architecture.
 
 * Executing Jupyter notebooks in CANFAR on SRCNet nodes
+
+### Presentation for [SRCNet demo 6th Nov 2025](https://github.com/Zarquan/jordanita/blob/main/presentations/20251106-SRCNet-ExecutionBrokerDemo/20251106-SRCNet-ExecutionBrokerDemo.pdf)
+
+Good explanation of the messages that are sent to the boroker. The broker service was able launch a session in CANFAR, some of the time, BUT it was EXTREMELY fragile. It failed during the demo because I was hacking the authentication tokens to get it to work.
+
+The rushed implementation contains terrible code to manage the concurrent tasks. Work in December/January has been to replace the terrible code with a much more robust design. The new code base I am workin on is able to handle 1,000s of overlapping requests without getting confused.
+
+### Presentation for [SRCNet architecture meeting 9th Sept 2025](https://github.com/Zarquan/jordanita/blob/main/presentations/20250909-SRCNet-ExecutionDataModel/20250909-SRCnet-ExecutionDataModel.pdf)
+(*) Note - the meeting ran out of time, so this was not actually presented at the meeting
+
+Several SRCNet components were potentially using very similar data models to describe similar things. Splitting the Execution Broker model into re-usable components that could be common for all the SRCNet services. Things like Executable, DataResource, StorageResource, ComputeResource etc. Then these could be used like Lego bricks to build the interfaces for the SRCNet services.
+
+Work on the OpenAPI tooling means we can split the OpenAPI schema into separate components thatcan be re-used a Lego bricks to build the APIs for different services.
+
+## Execution Broker [progress report 22nd May 2025](https://github.com/Zarquan/jordanita/blob/main/presentations/20250522-SRCNet-ExecutionBroker/20250522-SRCnet-ExecutionBroker.pdf)
+
+Progress report on the scheduling business logic. Using hardcoded download time values for each DataLake node the scheduling logic would select the best available estimate for a given data resources and calclate the appropriate preparation and start time for the the offers.
+
+The more remote the data, the longer the preparation time, the later the start time offered by the service.
+
+## [COR-821] [ivo://.... identifiers for SRCNet DataProducts](https://confluence.skatelescope.org/pages/viewpage.action?pageId=319989873)
+
+A pattern for how to use ivo:// identifiers in SKAO and SCRNet to enable software to distinguish between data data created by SKAO and data created by other data providers.
+
+
+## Execution Broker in 2026
 
 Targets for 2026 are up for discussion.
 


### PR DESCRIPTION
Updated the Execution Broker documentation to reflect progress and targets for 2026, including details on previous presentations and improvements made.